### PR TITLE
--env-vars オプションの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,8 @@ spec:
 ...skip...
 ```
 
-
 ```shell
-> ksubst -e env.assets -r assets assets2
+> ksubst --env-file env.assets -r assets assets2
 > diff -u <(find assets -type f -exec cat {} +)  <(find assets2 -type f -exec cat {} +)
 
 ...skip...
@@ -83,6 +82,7 @@ spec:
 +        app: hoge-name
 ```
 
+or `ksubst -r assets assets2 --env-vars 'FEATURE=hoge2,VERSION=123'`
 
 ## License
 

--- a/assets/foo.yaml
+++ b/assets/foo.yaml
@@ -9,7 +9,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ${FEATURE-}ing
+  name: ${FEATURE-}${VERSION.}ing
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:

--- a/env.assets
+++ b/env.assets
@@ -1,1 +1,2 @@
 FEATURE=hoge
+VERSION=123


### PR DESCRIPTION
## 概要

このプルリクエストでは、環境変数をコマンドラインから直接指定できる `--env-vars` オプションを追加しました。このオプションにより、ユーザーは環境変数ファイルを使用せずに、即座に変数を指定して置換処理を行うことができます。

## 使用方法

- **環境変数をコマンドラインから指定する場合:**

  ```bash
  ./your_program --env-vars 'HOGE=hoge,FUGA=fuga' [その他のオプション]
  ```

  - `HOGE` と `FUGA` の値がそれぞれ `hoge` と `fuga` に置換されます。

- **`.env` ファイルを使用する場合（従来通り）:**

  ```bash
  ./your_program -e path/to/.env [その他のオプション]
  ```

- **注意事項:**
  - `--env-vars` と `-e` オプションは同時に使用できません。
  - どちらのオプションも指定しない場合は、システムの環境変数が使用されます。

## 目的

- ユーザーが簡単に環境変数を指定できるようにし、スクリプトやCI/CDパイプラインでの柔軟な使用を可能にします。
- 環境変数ファイルを用意する手間を省き、簡易的な置換処理を迅速に行えるようにします。


