### PR TITLE
use `K{}` instead of `${}` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Its name and logic are similar to the [`envsubst`] GNU utility, but this support
 
 This project is a fork of [envsubst-rs](https://github.com/coreos/envsubst-rs). We greatly respect and appreciate the original work done by the `envsubst-rs` maintainers.
 
+## Why use K{} instead of ${}?
+
+In the original `envsubst`, the `${}` syntax is typically used for placeholders. However, in Kubernetes and Kustomize configurations, the metadata.name field does not allow the use of `$` symbols. As a result, if you use `${}` for variable substitution in `patches`, Kubernetes or Kustomize will ignore these placeholders, preventing the intended value replacement. Therefore, using a different syntax, such as `K{}`, ensures compatibility and allows for seamless substitution.
+
 ## Example
 
 You can run an example to see how the library works by executing:

--- a/assets/foo.yaml
+++ b/assets/foo.yaml
@@ -1,15 +1,15 @@
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
-  name: ${FEATURE-}mc
+  name: K{FEATURE-}mc
 spec:
   domains:
-    - ${FEATURE.}example.com
+    - K{FEATURE.}example.com
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ${FEATURE-}${VERSION.}ing
+  name: K{FEATURE-}K{VERSION.}ing
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:

--- a/assets/nested/foo.ts
+++ b/assets/nested/foo.ts
@@ -1,1 +1,1 @@
-console.log(`Hello, ${FEATURE}`);
+console.log(`Hello, K{FEATURE}`);

--- a/assets/nested/foo.yaml
+++ b/assets/nested/foo.yaml
@@ -1,22 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ${FEATURE-}name
+  name: K{FEATURE-}name
   labels:
-    app: ${FEATURE-}name
+    app: K{FEATURE-}name
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ${FEATURE-}name
+      app: K{FEATURE-}name
   template:
     metadata:
-      name: ${FEATURE-}name
+      name: K{FEATURE-}name
       labels:
-        app: ${FEATURE-}name
+        app: K{FEATURE-}name
     spec:
       containers:
-        - name: ${FEATURE-}name
+        - name: K{FEATURE-}name
           image: nginx
           imagePullPolicy: IfNotPresent
           ports:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! all matching placeholders.
 //!
 //! Its name and logic is similar to the [`envsubst`] GNU utility, but
-//! this only supports braces-delimited variables (i.e. `${foo}`) and
+//! this only supports braces-delimited variables (i.e. `K{foo}`) and
 //! takes replacement values from an explicit map of variables.
 //!
 //! [`envsubst`]: https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html
@@ -13,17 +13,17 @@
 //! ## Example
 //!
 //! ```rust
-//! let base_url = "${protocol}://${hostname}/${endpoint}";
-//! assert!(envsubst::is_templated(base_url));
+//! let base_url = "K{protocol}://K{hostname}/K{endpoint}";
+//! assert!(ksubst::is_templated(base_url));
 //!
 //! let mut context = std::collections::HashMap::new();
 //! context.insert("protocol".to_string(), "https".to_string());
 //! context.insert("hostname".to_string(), "example.com".to_string());
 //! context.insert("endpoint".to_string(), "login".to_string());
-//! assert!(envsubst::validate_vars(&context).is_ok());
+//! assert!(ksubst::validate_vars(&context).is_ok());
 //!
-//! let final_url = envsubst::substitute(base_url, &context).unwrap();
-//! assert!(!envsubst::is_templated(&final_url));
+//! let final_url = ksubst::substitute(base_url, &context).unwrap();
+//! assert!(!ksubst::is_templated(&final_url));
 //! assert_eq!(final_url, "https://example.com/login");
 //! ```
 
@@ -39,7 +39,7 @@ pub struct Error(String);
 
 /// Substitute variables in a template string with optional suffix handling.
 ///
-/// This function replaces tokens of the form `${VAR}`, `${VAR.}`, `${VAR-}` in the template string.
+/// This function replaces tokens of the form `K{VAR}`, `K{VAR.}`, `K{VAR-}` in the template string.
 /// - If the variable `VAR` has a non-empty value, it replaces the placeholder with `value + suffix`.
 /// - If the variable `VAR` has an empty value (`""`), it replaces the entire placeholder (including the suffix) with an empty string.
 pub fn substitute<T>(template: T, variables: &HashMap<String, String>) -> Result<String, Error>
@@ -53,8 +53,8 @@ where
 
     validate_vars(variables)?;
 
-    // Regular expression to match placeholders like ${VAR}, ${VAR.}, ${VAR-}
-    let re = Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)([\.\-][^}]*)?\}").unwrap();
+    // Regular expression to match placeholders like K{VAR}, K{VAR.}, K{VAR-}
+    let re = Regex::new(r"K\{([A-Za-z_][A-Za-z0-9_]*)([\.\-][^}]*)?\}").unwrap();
 
     output = re
         .replace_all(&output, |caps: &regex::Captures| {
@@ -82,7 +82,7 @@ pub fn is_templated<S>(input: S) -> bool
 where
     S: AsRef<str>,
 {
-    let re = Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)([\.\-][^}]*)?\}").unwrap();
+    let re = Regex::new(r"K\{([A-Za-z_][A-Za-z0-9_]*)([\.\-][^}]*)?\}").unwrap();
     re.is_match(input.as_ref())
 }
 
@@ -90,7 +90,7 @@ where
 ///
 /// This check whether substitution variables are valid. In order to make
 /// substitution deterministic, the following characters are not allowed
-/// within variables names nor values: `$`, `{`, `}`.
+/// within variables names nor values: `K`, `{`, `}`.
 pub fn validate_vars(variables: &HashMap<String, String>) -> Result<(), Error> {
     for (k, v) in variables {
         validate(k, "key")?;
@@ -104,7 +104,7 @@ fn validate<S>(value: S, kind: &str) -> Result<(), Error>
 where
     S: AsRef<str>,
 {
-    let forbidden = &["$", "{", "}"];
+    let forbidden = &["K{", "{", "}"];
     for c in forbidden {
         if value.as_ref().contains(c) {
             let err_msg = format!(
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn basic_subst() {
-        let template = "foo ${VAR} bar";
+        let template = "foo K{VAR} bar";
         let mut env = HashMap::new();
         env.insert("VAR".to_string(), "var".to_string());
 
@@ -140,10 +140,13 @@ mod tests {
         let plain = "foo";
         assert!(!is_templated(plain));
 
-        let template = "foo ${VAR} bar";
+        let template = "foo K{VAR} bar";
         assert!(is_templated(template));
 
-        let starting = "foo${";
+        let template = "foo k{VAR} bar";
+        assert!(!is_templated(template));
+
+        let starting = "fooK{";
         assert!(!is_templated(starting));
 
         let ending = "foo}";
@@ -152,7 +155,7 @@ mod tests {
 
     #[test]
     fn basic_empty_vars() {
-        let template = "foo ${VAR} bar";
+        let template = "foo K{VAR} bar";
         let env = HashMap::new();
 
         let out = substitute(template, &env).unwrap();
@@ -161,7 +164,7 @@ mod tests {
 
     #[test]
     fn dollar_bracket() {
-        let template = "foo ${ bar";
+        let template = "foo K{ bar";
         let mut env = HashMap::new();
         env.insert("VAR".to_string(), "var".to_string());
 
@@ -171,21 +174,26 @@ mod tests {
 
     #[test]
     fn invalid_vars() {
-        let template = "foo ${VAR} bar";
+        let template = "foo K{VAR} bar";
         let mut env = HashMap::new();
-        env.insert("${VAR}".to_string(), "var".to_string());
+        env.insert("K{VAR}".to_string(), "var".to_string());
 
         substitute(template, &env).unwrap_err();
 
         let mut env = HashMap::new();
-        env.insert("VAR".to_string(), "${VAR}".to_string());
+        env.insert("VAR".to_string(), "K{".to_string());
 
         substitute(template, &env).unwrap_err();
+
+        let mut env = HashMap::new();
+        env.insert("VAR".to_string(), "K".to_string());
+
+        substitute(template, &env).unwrap();
     }
 
     #[test]
     fn test_substitute_with_suffix_non_empty_var() {
-        let template = "${VAR} ${VAR.} ${VAR-}";
+        let template = "K{VAR} K{VAR.} K{VAR-}";
         let mut variables = HashMap::new();
         variables.insert("VAR".to_string(), "hoge".to_string());
 
@@ -195,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_substitute_with_suffix_empty_var() {
-        let template = "${VAR} ${VAR.} ${VAR-}";
+        let template = "K{VAR} K{VAR.} K{VAR-}";
         let mut variables = HashMap::new();
         variables.insert("VAR".to_string(), "".to_string());
 
@@ -205,16 +213,16 @@ mod tests {
 
     #[test]
     fn test_substitute_with_missing_var() {
-        let template = "${VAR} ${VAR.} ${VAR-}";
+        let template = "K{VAR} K{VAR.} K{VAR-}";
         let variables = HashMap::new();
 
         let result = substitute(template, &variables).unwrap();
-        assert_eq!(result, "${VAR} ${VAR.} ${VAR-}");
+        assert_eq!(result, "K{VAR} K{VAR.} K{VAR-}");
     }
 
     #[test]
     fn test_substitute_with_complex_suffix() {
-        let template = "${VAR.suffix} ${VAR-extra}";
+        let template = "K{VAR.suffix} K{VAR-extra}";
         let mut variables = HashMap::new();
         variables.insert("VAR".to_string(), "value".to_string());
 


### PR DESCRIPTION
元々の `envsubst` では、`${}` 記法がプレースホルダーとして一般的に使われます。しかし、Kubernetes や Kustomize の設定では、`metadata.name` フィールドに `$` 記号を使用することが許可されていません。そのため、`patches` 内で変数の置き換えに `${}` を使用していると、Kubernetes や Kustomize によってこれらのプレースホルダーが無視され、意図した値の置き換えができなくなります。したがって、`K{}` のような異なる記法を使うことで、互換性が保たれ、スムーズに置き換えが行えるようになります。